### PR TITLE
make compilable/runnable on 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 //    modCompileOnly ("com.simibubi:Create:mc1.18.2_v0.4.1+635") //doesn't work on 1.19
     modImplementation ("dev.emi:trinkets:${project.trinkets_version}") { exclude group: "com.terraformersmc" }
     modImplementation ("dev.emi:emi:${emi_version}")
-    modImplementation 'io.github.ladysnake:BLAST:1.10' //requires blast in mavenLocal, can't be downloaded from cursemaven
+    modImplementation 'io.github.ladysnake:BLAST:1.10'
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,10 @@ dependencies {
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation ("net.fabricmc:fabric-loader:${project.loader_version}")
     modImplementation ("net.fabricmc.fabric-api:fabric-api:${project.fabric_version}")
-    modCompileOnly ("com.simibubi:Create:mc1.18.2_v0.4.1+635")
-    modImplementation ("dev.emi:trinkets:${project.trinkets_version}")
+//    modCompileOnly ("com.simibubi:Create:mc1.18.2_v0.4.1+635") //doesn't work on 1.19
+    modImplementation ("dev.emi:trinkets:${project.trinkets_version}") { exclude group: "com.terraformersmc" }
     modImplementation ("dev.emi:emi:${emi_version}")
-    modImplementation 'io.github.ladysnake:BLAST:1.10'
+    modImplementation 'io.github.ladysnake:BLAST:1.10' //requires blast in mavenLocal, can't be downloaded from cursemaven
 }
 
 processResources {

--- a/src/main/java/amymialee/halfdoors/compat/blast/BlastCompatHandler.java
+++ b/src/main/java/amymialee/halfdoors/compat/blast/BlastCompatHandler.java
@@ -19,7 +19,7 @@ public class BlastCompatHandler {
 
     public static boolean explodeIfBomb(Entity target, float bonus) {
         if (target instanceof BombEntity bomb) {
-            bomb.setExplosionRadius(bomb.getExplosionRadius() * bonus);
+//            bomb.setExplosionRadius(bomb.getExplosionRadius() * bonus); //no longer exists in BombEntity
             bomb.explode();
             return true;
         }


### PR DESCRIPTION
Does a couple things to make this work on 1.19:
- comment out create runtime dep - it's not used at all and doesn't work on 1.19
- excludes Mod Menu dependency in Trinkets - it's broken on 1.19 and the fix hasn't been published
- removes setExplosionRadius call - that method doesn't seem to exist in blast anymore

This is a very rough solution but it at least makes it compile