### PR TITLE
Added generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,4 +118,3 @@ run/
 !gradle-wrapper.jar
 
 *.cache/
-*generated/

--- a/src/main/generated/assets/halfdoors/blockstates/acacia_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/acacia_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/acacia_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/bamboo_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/bamboo_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/bamboo_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/birch_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/birch_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/birch_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/cherry_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/cherry_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/cherry_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/crimson_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/crimson_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/crimson_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/dark_oak_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/dark_oak_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/dark_oak_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/iron_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/iron_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/iron_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/jungle_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/jungle_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/jungle_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/mangrove_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/mangrove_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/mangrove_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/oak_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/oak_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/oak_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/spruce_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/spruce_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/spruce_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/blockstates/warped_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/blockstates/warped_halfdoor.json
@@ -1,0 +1,244 @@
+{
+  "variants": {
+    "facing=east,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_left"
+    },
+    "facing=east,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 90
+    },
+    "facing=east,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_right"
+    },
+    "facing=east,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 270
+    },
+    "facing=east,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 270
+    },
+    "facing=north,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_right"
+    },
+    "facing=north,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_right"
+    },
+    "facing=north,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 270
+    },
+    "facing=north,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 180
+    },
+    "facing=north,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 90
+    },
+    "facing=south,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 180
+    },
+    "facing=south,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 90
+    },
+    "facing=south,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_left"
+    },
+    "facing=south,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_left"
+    },
+    "facing=west,hinge=left,open=false,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=false,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 180
+    },
+    "facing=west,hinge=left,open=true,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=left,open=true,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 270
+    },
+    "facing=west,hinge=right,open=false,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=false,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_right",
+      "y": 180
+    },
+    "facing=west,hinge=right,open=true,section=center": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=isolated": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=lower": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 90
+    },
+    "facing=west,hinge=right,open=true,section=upper": {
+      "model": "halfdoors:block/warped_halfdoor_left",
+      "y": 90
+    }
+  }
+}

--- a/src/main/generated/assets/halfdoors/lang/en_us.json
+++ b/src/main/generated/assets/halfdoors/lang/en_us.json
@@ -1,0 +1,16 @@
+{
+  "block.halfdoors.acacia_halfdoor": "Acacia Halfdoor",
+  "block.halfdoors.bamboo_halfdoor": "Bamboo Halfdoor",
+  "block.halfdoors.birch_halfdoor": "Birch Halfdoor",
+  "block.halfdoors.cherry_halfdoor": "Cherry Halfdoor",
+  "block.halfdoors.crimson_halfdoor": "Crimson Halfdoor",
+  "block.halfdoors.dark_oak_halfdoor": "Dark Oak Halfdoor",
+  "block.halfdoors.iron_fence_gate": "Iron Fence Gate",
+  "block.halfdoors.iron_halfdoor": "Iron Halfdoor",
+  "block.halfdoors.jungle_halfdoor": "Jungle Halfdoor",
+  "block.halfdoors.mangrove_halfdoor": "Mangrove Halfdoor",
+  "block.halfdoors.oak_halfdoor": "Oak Halfdoor",
+  "block.halfdoors.spruce_halfdoor": "Spruce Halfdoor",
+  "block.halfdoors.warped_halfdoor": "Warped Halfdoor",
+  "itemGroup.halfdoors.halfdoors_group": "Halfdoors"
+}

--- a/src/main/generated/assets/halfdoors/models/block/acacia_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/acacia_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/acacia_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/acacia_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/acacia_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/acacia_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/bamboo_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/bamboo_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/bamboo_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/bamboo_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/bamboo_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/bamboo_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/birch_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/birch_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/birch_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/birch_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/birch_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/birch_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/cherry_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/cherry_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/cherry_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/cherry_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/cherry_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/cherry_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/crimson_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/crimson_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/crimson_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/crimson_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/crimson_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/crimson_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/dark_oak_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/dark_oak_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/dark_oak_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/dark_oak_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/dark_oak_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/dark_oak_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/iron_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/iron_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/iron_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/iron_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/iron_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/iron_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/jungle_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/jungle_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/jungle_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/jungle_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/jungle_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/jungle_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/mangrove_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/mangrove_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/mangrove_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/mangrove_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/mangrove_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/mangrove_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/oak_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/oak_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/oak_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/oak_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/oak_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/oak_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/spruce_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/spruce_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/spruce_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/spruce_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/spruce_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/spruce_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/warped_halfdoor_left.json
+++ b/src/main/generated/assets/halfdoors/models/block/warped_halfdoor_left.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_left",
+  "textures": {
+    "halfdoor": "halfdoors:block/warped_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/block/warped_halfdoor_right.json
+++ b/src/main/generated/assets/halfdoors/models/block/warped_halfdoor_right.json
@@ -1,0 +1,6 @@
+{
+  "parent": "halfdoors:block/template_halfdoor_right",
+  "textures": {
+    "halfdoor": "halfdoors:block/warped_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/acacia_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/acacia_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/acacia_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/bamboo_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/bamboo_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/bamboo_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/birch_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/birch_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/birch_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/cherry_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/cherry_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/cherry_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/crimson_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/crimson_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/crimson_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/dark_oak_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/dark_oak_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/dark_oak_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/iron_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/iron_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/iron_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/jungle_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/jungle_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/jungle_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/mangrove_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/mangrove_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/mangrove_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/oak_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/oak_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/oak_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/spruce_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/spruce_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/spruce_halfdoor"
+  }
+}

--- a/src/main/generated/assets/halfdoors/models/item/warped_halfdoor.json
+++ b/src/main/generated/assets/halfdoors/models/item/warped_halfdoor.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "halfdoors:item/warped_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/acacia_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/acacia_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:acacia_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:acacia_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:acacia_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/bamboo_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/bamboo_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:bamboo_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:bamboo_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:bamboo_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/birch_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/birch_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:birch_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:birch_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:birch_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/cherry_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/cherry_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:cherry_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:cherry_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:cherry_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/crimson_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/crimson_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:crimson_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:crimson_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:crimson_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/dark_oak_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/dark_oak_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:dark_oak_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:dark_oak_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:dark_oak_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/iron_fence_gate.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/iron_fence_gate.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_gate": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:iron_ingot"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_sides": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:iron_nugget"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:iron_fence_gate"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_sides",
+      "has_gate"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:iron_fence_gate"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/iron_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/iron_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:iron_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:iron_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:iron_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/jungle_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/jungle_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:jungle_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:jungle_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:jungle_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/mangrove_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/mangrove_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:mangrove_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:mangrove_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:mangrove_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/oak_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/oak_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:oak_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:oak_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:oak_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/spruce_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/spruce_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:spruce_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:spruce_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:spruce_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/advancement/recipes/redstone/warped_halfdoor.json
+++ b/src/main/generated/data/halfdoors/advancement/recipes/redstone/warped_halfdoor.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_door": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:warped_door"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "halfdoors:warped_halfdoor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_door"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "halfdoors:warped_halfdoor"
+    ]
+  }
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/acacia_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/acacia_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:acacia_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/bamboo_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/bamboo_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:bamboo_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/birch_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/birch_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:birch_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/cherry_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/cherry_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:cherry_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/crimson_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/crimson_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:crimson_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/dark_oak_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/dark_oak_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:dark_oak_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/iron_fence_gate.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/iron_fence_gate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:iron_fence_gate"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/iron_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/iron_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:iron_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/jungle_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/jungle_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:jungle_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/mangrove_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/mangrove_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:mangrove_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/oak_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/oak_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:oak_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/spruce_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/spruce_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:spruce_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/loot_table/blocks/warped_halfdoor.json
+++ b/src/main/generated/data/halfdoors/loot_table/blocks/warped_halfdoor.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "halfdoors:warped_halfdoor"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/halfdoors/recipe/acacia_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/acacia_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:acacia_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:acacia_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/bamboo_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/bamboo_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:bamboo_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:bamboo_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/birch_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/birch_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:birch_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:birch_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/cherry_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/cherry_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:cherry_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:cherry_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/crimson_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/crimson_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:crimson_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:crimson_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/dark_oak_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/dark_oak_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:dark_oak_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:dark_oak_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/iron_fence_gate.json
+++ b/src/main/generated/data/halfdoors/recipe/iron_fence_gate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "g": {
+      "item": "minecraft:iron_ingot"
+    },
+    "s": {
+      "item": "minecraft:iron_nugget"
+    }
+  },
+  "pattern": [
+    "sgs",
+    "sgs"
+  ],
+  "result": {
+    "count": 1,
+    "id": "halfdoors:iron_fence_gate"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/iron_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/iron_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:iron_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:iron_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/jungle_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/jungle_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:jungle_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:jungle_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/mangrove_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/mangrove_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:mangrove_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:mangrove_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/oak_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/oak_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:oak_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:oak_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/spruce_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/spruce_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:spruce_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:spruce_halfdoor"
+  }
+}

--- a/src/main/generated/data/halfdoors/recipe/warped_halfdoor.json
+++ b/src/main/generated/data/halfdoors/recipe/warped_halfdoor.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "redstone",
+  "key": {
+    "d": {
+      "item": "minecraft:warped_door"
+    }
+  },
+  "pattern": [
+    "ddd"
+  ],
+  "result": {
+    "count": 6,
+    "id": "halfdoors:warped_halfdoor"
+  }
+}

--- a/src/main/generated/data/minecraft/tags/block/doors.json
+++ b/src/main/generated/data/minecraft/tags/block/doors.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "halfdoors:iron_halfdoor"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/block/fence_gates.json
+++ b/src/main/generated/data/minecraft/tags/block/fence_gates.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "halfdoors:iron_fence_gate"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/block/mineable/axe.json
+++ b/src/main/generated/data/minecraft/tags/block/mineable/axe.json
@@ -1,0 +1,15 @@
+{
+  "values": [
+    "halfdoors:oak_halfdoor",
+    "halfdoors:spruce_halfdoor",
+    "halfdoors:birch_halfdoor",
+    "halfdoors:jungle_halfdoor",
+    "halfdoors:acacia_halfdoor",
+    "halfdoors:dark_oak_halfdoor",
+    "halfdoors:mangrove_halfdoor",
+    "halfdoors:cherry_halfdoor",
+    "halfdoors:bamboo_halfdoor",
+    "halfdoors:crimson_halfdoor",
+    "halfdoors:warped_halfdoor"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/src/main/generated/data/minecraft/tags/block/mineable/pickaxe.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "halfdoors:iron_halfdoor",
+    "halfdoors:iron_fence_gate"
+  ]
+}

--- a/src/main/generated/data/minecraft/tags/block/wooden_doors.json
+++ b/src/main/generated/data/minecraft/tags/block/wooden_doors.json
@@ -1,0 +1,15 @@
+{
+  "values": [
+    "halfdoors:oak_halfdoor",
+    "halfdoors:spruce_halfdoor",
+    "halfdoors:birch_halfdoor",
+    "halfdoors:jungle_halfdoor",
+    "halfdoors:acacia_halfdoor",
+    "halfdoors:dark_oak_halfdoor",
+    "halfdoors:mangrove_halfdoor",
+    "halfdoors:cherry_halfdoor",
+    "halfdoors:bamboo_halfdoor",
+    "halfdoors:crimson_halfdoor",
+    "halfdoors:warped_halfdoor"
+  ]
+}


### PR DESCRIPTION
A partial fix for #20 ; adds all missing generated files (excluding the `.cache` directory) by removing `*generated/` from the `.gitignore` and running datagen.

Remaining TODO: Create the following:
* `src/main/resources/assets/halfdoors/textures/block/mangrove_halfdoor.png`
* `src/main/resources/assets/halfdoors/textures/block/cherry_halfdoor.png`
* `src/main/resources/assets/halfdoors/textures/block/bamboo_halfdoor.png`